### PR TITLE
Allow "notes" lookup

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -111,6 +111,10 @@ class Bitwarden(object):
     def get_entry(self, key, field):
         return self._run(["get", field, key]).decode('utf-8')
 
+    def get_notes(self, key):
+        data = json.loads(self.get_entry(key, 'item'))
+        return data['notes']
+
     def get_custom_field(self, key, field):
         data = json.loads(self.get_entry(key, 'item'))
         return next(x for x in data['fields'] if x['name'] == field)['value']
@@ -135,6 +139,8 @@ class LookupModule(LookupBase):
         for term in terms:
             if kwargs.get('custom_field'):
                 values.append(bw.get_custom_field(term, field))
+            elif field == 'notes':
+                values.append(bw.get_notes(term))
             else:
                 values.append(bw.get_entry(term, field))
         return values


### PR DESCRIPTION
Have to create explicit lookup for "notes" because all types have it, but the cli doesn't support grabbing that field directly.

My use case is storing SSL Certificates as Secure Notes.