### PR TITLE
Add platforms to galaxy_info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,3 +4,7 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.5
   galaxy_tags: [password, secret, bitwarden, credentials]
+  platforms:
+    - name: GenericLinux
+    - name: macOS
+    - name: Windows


### PR DESCRIPTION
Adds platforms to galaxy_info to comply with ansible-lint.
