### PR TITLE
Python 3-friendly error handling

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -14,7 +14,7 @@ import json
 import os
 import sys
 
-from subprocess import Popen, PIPE, check_output
+from subprocess import Popen, PIPE, STDOUT, check_output
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -82,29 +82,28 @@ class Bitwarden(object):
         return 'BW_SESSION' in os.environ
 
     def _run(self, args):
-        p = Popen([self.cli_path] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        out, err = p.communicate()
+        p = Popen([self.cli_path] + args, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+        out, _ = p.communicate()
         out = out.decode()
-        err = err.decode()
         rc = p.wait()
         if rc != 0:
             display.debug("Received error when running '{0} {1}': {2}"
                           .format(self.cli_path, args, out))
-            if err.startswith("Vault is locked."):
+            if out.startswith("Vault is locked."):
                 raise AnsibleError("Error accessing Bitwarden vault. "
                                    "Run 'bw unlock' to unlock the vault.")
-            elif err.startswith("You are not logged in."):
+            elif out.startswith("You are not logged in."):
                 raise AnsibleError("Error accessing Bitwarden vault. "
                                    "Run 'bw login' to login.")
-            elif err.startswith("Failed to decrypt."):
+            elif out.startswith("Failed to decrypt."):
                 raise AnsibleError("Error accessing Bitwarden vault. "
                                    "Make sure BW_SESSION is set properly.")
-            elif err.startswith("Not found."):
+            elif out.startswith("Not found."):
                 raise AnsibleError("Error accessing Bitwarden vault. "
                         "Specified item not found: {}".format(args[-1]))
             else:
                 raise AnsibleError("Unknown failure in 'bw' command: "
-                                   "{0}".format(err))
+                                   "{0}".format(out))
         return out.strip()
 
     def sync(self):


### PR DESCRIPTION
This PR just fixes a few things with error handling and addresses some Python 3 compatibility stuff.

* It looks like `bw` now sends errors to stderr instead of stdout, so I changed the error checking lines to check against stderr instead of stdout
* Python 3 couldn't check errors correctly (as `.startswith()` was comparing the bytes output of `Popen` against str, so I changed things to immediately run .decode() against the output from Popen so that the string comparisons in the error checking work properly
* When a secret is not found, it now is printed in the ansible error - this makes it much easier to identify which lookup failed if performing multiple lookups at the same time.