### PR TITLE
Change logged_in func to parse bw status instead of BW_SESSION

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -79,7 +79,11 @@ class Bitwarden(object):
 
     @property
     def logged_in(self):
-        return 'BW_SESSION' in os.environ
+        # Parse Bitwarden status to check if logged in
+        if self.status() == 'unlocked':
+            return True
+        else:
+            return False
 
     def _run(self, args):
         p = Popen([self.cli_path] + args, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
@@ -108,6 +112,13 @@ class Bitwarden(object):
 
     def sync(self):
         self._run(['sync'])
+
+    def status(self):
+        try:
+            data = json.loads(self._run(['status']))
+        except json.decoder.JSONDecodeError as e:
+            raise AnsibleError("Error decoding Bitwarden status: %s" % e)
+        return data['status']
 
     def get_entry(self, key, field):
         return self._run(["get", field, key])


### PR DESCRIPTION
I use https://github.com/mjslabs/bitagent to handle Bitwarden sessions as I got fed up of having to "bw login" constantly.
Bitagent does not set BW_SESSION so this PR modifies the logged_in() func to parse bw status instead of relying on BW_SESSION.

I'm not a python developer so the exception handling etc might need tweaking.