### PR TITLE
Add `--version` when testing if `bw` command works

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -69,7 +69,7 @@ class Bitwarden(object):
     def __init__(self, path):
         self._cli_path = path
         try:
-            check_output(self._cli_path)
+            check_output([self._cli_path, "--version"])
         except OSError:
             raise AnsibleError("Command not found: {0}".format(self._cli_path))
 


### PR DESCRIPTION
The bw cli program recently changed so that running `bw` without any
arguments returned a failing status, causing `subprocess` to raise a
`CalledProcessError` that resulted in the lookup module
failing. Invoking the program with a no-op argument like `--version`
causes it to exit successfully, which allows us to test for its
presence.

Fixes #14.