### PR TITLE
Add cache functionality to improve lookup executing times

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -102,7 +102,6 @@ class Bitwarden(object):
 
     def cache(func):
         def inner(*args, **kwargs):
-            self = args[0]
             key = '_'.join(args[1:])
 
             if key not in CACHE:

--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -65,6 +65,7 @@ RETURN = """
 
 # Global variables
 CACHE = dict()
+LOGGED_IN = None
 
 
 class Bitwarden(object):
@@ -91,11 +92,13 @@ class Bitwarden(object):
 
     @property
     def logged_in(self):
-        # Parse Bitwarden status to check if logged in
-        if self.status() == 'unlocked':
-            return True
-        else:
-            return False
+        global LOGGED_IN
+
+        if LOGGED_IN is None:
+            # Parse Bitwarden status to check if logged in
+            LOGGED_IN = (self.status() == 'unlocked')
+
+        return LOGGED_IN
 
     def cache(func):
         def inner(*args, **kwargs):

--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -168,10 +168,17 @@ class Bitwarden(object):
 
 class LookupModule(LookupBase):
 
-    def run(self, terms, variables=None, **kwargs):
-        bw = Bitwarden(path=kwargs.get('path', 'bw'))
+    def __init__(self, *args, **kwargs):
+        self.bw = None
 
-        if not bw.logged_in:
+        # Init super
+        super().__init__(*args, **kwargs)
+
+    def run(self, terms, variables=None, **kwargs):
+        if not self.bw:
+            self.bw = Bitwarden(path=kwargs.get('path', 'bw'))
+
+        if not self.bw.logged_in:
             raise AnsibleError("Not logged into Bitwarden: please run "
                                "'bw login', or 'bw unlock' and set the "
                                "BW_SESSION environment variable first")
@@ -180,26 +187,26 @@ class LookupModule(LookupBase):
         values = []
 
         if kwargs.get('sync'):
-            bw.sync()
+            self.bw.sync()
         if kwargs.get('session'):
-            bw.session = kwargs.get('session')
+            self.bw.session = kwargs.get('session')
 
         for term in terms:
             if kwargs.get('custom_field'):
-                values.append(bw.get_custom_field(term, field))
+                values.append(self.bw.get_custom_field(term, field))
             elif field == 'notes':
-                values.append(bw.get_notes(term))
+                values.append(self.bw.get_notes(term))
             elif kwargs.get('attachments'):
                 if kwargs.get('itemid'):
                     itemid = kwargs.get('itemid')
                     output = kwargs.get('output', term)
-                    values.append(bw.get_attachments(term, itemid, output))
+                    values.append(self.bw.get_attachments(term, itemid, output))
                 else:
                     raise AnsibleError("Missing value for - itemid - "
                                        "Please set parameters as example: - "
                                        "itemid='f12345-d343-4bd0-abbf-4532222' ")
             else:
-                values.append(bw.get_entry(term, field))
+                values.append(self.bw.get_entry(term, field))
         return values
 
 

--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -63,12 +63,15 @@ RETURN = """
       - Items from Bitwarden vault
 """
 
+# Global variables
+CACHE = dict()
+
 
 class Bitwarden(object):
     def __init__(self, path):
         self._cli_path = path
         self._bw_session = ""
-        self.cache = dict()
+
         try:
             check_output([self._cli_path, "--version"])
         except OSError:
@@ -97,13 +100,13 @@ class Bitwarden(object):
     def cache(func):
         def inner(*args, **kwargs):
             self = args[0]
-            cache_key = '_'.join(args[1:])
+            key = '_'.join(args[1:])
 
-            if cache_key not in self.cache:
+            if key not in CACHE:
                 value = func(*args, **kwargs)
-                self.cache[cache_key] = value
+                CACHE[key] = value
 
-            return self.cache[cache_key]
+            return CACHE[key]
 
         return inner
 
@@ -137,6 +140,9 @@ class Bitwarden(object):
         return out.strip()
 
     def sync(self):
+        global CACHE
+
+        CACHE = dict()   # Clear cache to prevent using old values in cache
         self._run(['sync'])
 
     def status(self):


### PR DESCRIPTION
This PR adds caching functionality and improves executing times by remove unnecessary logged_in verification. As mentioned in #11, I've also encountered really long executing times in Ansible due to this plugin looking up passwords used in **become**. 

Due to how lookups are being handled internally by Ansible, the only way to implement a caching method is to use global variables. Implementing a cache in the actual `LookModule` or `Bitwarden` module is not beneficiary because these objects are recreated for every lookup. However importing the actual Lookup plugin happens rarely and thus the cache exists for a long time within a playbook.

Because the plugin check for every lookup whether BW is still logged in, this is also now improved to only check it initially and then trust that result. This also prevents a lot of unnecessary HTTP and CLI lookups.

Caching specific values greatly increases executing times because now certain passwords does not have to be looked up every time. E.g. in my situation the sudo password is looked up for every task, even for every item in a loop, this greatly increases execution time. With this new modification now a cache lookup is used instead of BW lookups. Manual verification shows that this has a extreme benefit on the execution time.

This PR will fix #11.