### PR TITLE
ignore stderr from `bw` command

### DIFF
--- a/lookup_plugins/bitwarden.py
+++ b/lookup_plugins/bitwarden.py
@@ -98,7 +98,7 @@ class Bitwarden(object):
         if self.session != "":
             my_env["BW_SESSION"] = self.session
         p = Popen([self.cli_path] + args, stdin=PIPE,
-                  stdout=PIPE, stderr=STDOUT, env=my_env)
+                  stdout=PIPE, env=my_env)
         out, _ = p.communicate()
         out = out.decode()
         rc = p.wait()


### PR DESCRIPTION
fixes #19 

it might be just a workaround, it would be better to pipe stderr to ansible logging.